### PR TITLE
Enable turbostreams

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -3,6 +3,6 @@ class JobsController < ApplicationController
     @jobs = Job.all
     @pct_jobs = Job.usage_w_percentage(Job.all_by_usage)
     @active_jobs = ActiveJobs.all
-    @cluster_ids = ActiveJobs.clusters.map { |c| c[:id] }
+    @cluster_ids = ActiveJobs.clusters.map { |c| c.id }
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -3,5 +3,6 @@ class JobsController < ApplicationController
     @jobs = Job.all
     @pct_jobs = Job.usage_w_percentage(Job.all_by_usage)
     @active_jobs = ActiveJobs.all
+    @cluster_ids = ActiveJobs.clusters.map { |c| c[:id] }
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,9 @@
 import "@hotwired/turbo-rails";
 import "./controllers";
 
+
+import * as Turbo from "@hotwired/turbo";
+
 window.addEventListener('turbo:load', (event) => {
     // Reload page after a given amount of time
     const SECONDS_BEFORE_RELOAD = 15 * 60;

--- a/app/jobs/cluster_status_job.rb
+++ b/app/jobs/cluster_status_job.rb
@@ -34,7 +34,12 @@ class ClusterStatusJob < ApplicationJob
     cluster = self.class.clusters[cluster_id.to_sym]
     info = self.class.info_from_jobs(cluster.job_adapter.info_all)
     # broadcast info
-    puts info
+    opts = {
+              partial: 'jobs/system_status',
+              target: "system_status_#{cluster_id}",
+              locals: { cluster_info: info, cluster_name: cluster_id }
+            }
+    Turbo::StreamsChannel.broadcast_replace_to("system_status", **opts)
     self.class.set(wait: 15.minutes).perform_later(cluster_id)
   end
 end

--- a/app/jobs/cluster_status_job.rb
+++ b/app/jobs/cluster_status_job.rb
@@ -36,10 +36,10 @@ class ClusterStatusJob < ApplicationJob
     # broadcast info
     opts = {
               partial: 'jobs/system_status',
-              target: "system_status_#{cluster_id}",
+              target: "cluster_status_#{cluster_id}",
               locals: { cluster_info: info, cluster_name: cluster_id }
             }
-    Turbo::StreamsChannel.broadcast_replace_to("system_status_#{cluster_id}", **opts)
-    self.class.set(wait: 3.minutes).perform_later(cluster_id)
+    Turbo::StreamsChannel.broadcast_replace_to("cluster_status_#{cluster_id}", **opts)
+    self.class.set(wait: 30.seconds).perform_later(cluster_id)
   end
 end

--- a/app/jobs/cluster_status_job.rb
+++ b/app/jobs/cluster_status_job.rb
@@ -39,7 +39,7 @@ class ClusterStatusJob < ApplicationJob
               target: "system_status_#{cluster_id}",
               locals: { cluster_info: info, cluster_name: cluster_id }
             }
-    Turbo::StreamsChannel.broadcast_replace_to("system_status", **opts)
-    self.class.set(wait: 15.minutes).perform_later(cluster_id)
+    Turbo::StreamsChannel.broadcast_replace_to("system_status_#{cluster_id}", **opts)
+    self.class.set(wait: 3.minutes).perform_later(cluster_id)
   end
 end

--- a/app/models/active_jobs.rb
+++ b/app/models/active_jobs.rb
@@ -4,14 +4,16 @@ class ActiveJobs
   class << self
     def clusters
       Rails.cache.fetch('clusters', expires_in: 12.hours) do
-        OodCore::Clusters.load_file('/etc/ood/config/clusters.d/').reject do |c|
-          !c.errors.empty? || !c.allow? || c.kubernetes? || c.linux_host?
-        end
+        OodCore::Clusters.new(
+          OodCore::Clusters.load_file('/etc/ood/config/clusters.d/').reject do |c|
+            !c.errors.empty? || !c.allow? || c.kubernetes? || c.linux_host?
+          end
+        )
       end
     end
 
     def all
-      Rails.cache.fetch('clusters', expires_in: 30.minutes) do
+      Rails.cache.fetch('all_jobs', expires_in: 30.minutes) do
         clusters.map do |c|
           {
             'cluster' => c.id,

--- a/app/views/jobs/_system_status.html.erb
+++ b/app/views/jobs/_system_status.html.erb
@@ -1,7 +1,5 @@
-<%- cluster_info = get_cluster_info(jobs) -%>
-
 <div class='container border py-1 rounded-1'>
-    <h2><%= cluster.capitalize() %> Cluster</h2>
+    <h2><%= cluster_name.capitalize() %> Cluster</h2>
     <div class="row justify-content-center">
         <div class="col">
             <div class="barchart">

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -1,7 +1,14 @@
+
 <div class='row my-2'>
-  <%- @active_jobs.each do |data| -%>
+  <%- @cluster_ids.each do |cluster| -%>
   <div class='col-md-6 col-xs-12 p-2'>
-    <%= render partial: 'system_status', locals: { cluster: data['cluster'], jobs: data['jobs'] } %>
+    <turbo-stream action="replace" target="system_status_#{cluster}">
+      <template>
+        <div id="system_status_#{cluster}">
+          waiting to populate data for <%= cluster %>.
+        </div>
+      </template>
+    </turbo-stream>
   </div>
   <%- end -%>
 </div>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -2,16 +2,12 @@
 <div class='row my-2'>
   <%- @cluster_ids.each do |cluster| -%>
   <div class='col-md-6 col-xs-12 p-2'>
-    <turbo-stream action="replace" target="system_status_#{cluster}">
-      <template>
-        <div id="system_status_#{cluster}">
-          waiting to populate data for <%= cluster %>.
-        </div>
-      </template>
-    </turbo-stream>
+    <%= turbo_stream_from "cluster_status_#{cluster}" %>
   </div>
   <%- end -%>
 </div>
+
+
 
 <div class='row pb-3 justify-content-center'>
   <div class='col-md-8'>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -3,6 +3,9 @@
   <%- @cluster_ids.each do |cluster| -%>
   <div class='col-md-6 col-xs-12 p-2'>
     <%= turbo_stream_from "cluster_status_#{cluster}" %>
+    <div id="cluster_status_<%= cluster %>">
+      page loading ...
+    </div>
   </div>
   <%- end -%>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <meta name="action-cable-url" content="/pun/<%= Rails.env.development? ? 'dev' : 'sys' %>/osc-reporting/cable">
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module OscReporting
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.action_cable.allowed_request_origins = [ "https://ondemand.osc.edu" ]
   end
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,0 +1,9 @@
+default:
+  adapter: asyncasfd
+
+test:
+  adapter: test
+
+development: &default
+
+production: &default

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,9 +1,11 @@
-default:
-  adapter: asyncasfd
+default: &default
+  adapter: async
 
 test:
   adapter: test
 
-development: &default
+development:
+  <<: *default
 
-production: &default
+production:
+  <<: *default

--- a/config/initializers/action_cable.rb
+++ b/config/initializers/action_cable.rb
@@ -1,0 +1,4 @@
+
+env = Rails.env.dev? ? 'dev' : 'sys'
+ActionCable.server.config.mount_path = "/pun/#{env}/dashboard"
+# ActionCable.server.config.cable = { adapter: 'async' }

--- a/config/initializers/action_cable.rb
+++ b/config/initializers/action_cable.rb
@@ -1,4 +1,0 @@
-
-env = Rails.env.dev? ? 'dev' : 'sys'
-ActionCable.server.config.mount_path = "/pun/#{env}/dashboard"
-# ActionCable.server.config.cable = { adapter: 'async' }

--- a/config/initializers/startup_jobs.rb
+++ b/config/initializers/startup_jobs.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.after_initialize do
-  ClusterStatusJob.perform_now('owens')
+  ClusterStatusJob.perform_later('owens')
 end

--- a/config/initializers/startup_jobs.rb
+++ b/config/initializers/startup_jobs.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.after_initialize do
-  ClusterStatusJob.perform_later('owens')
+  ClusterStatusJob.perform_now('owens')
 end

--- a/config/initializers/startup_jobs.rb
+++ b/config/initializers/startup_jobs.rb
@@ -1,5 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.after_initialize do
-  ClusterStatusJob.perform_now('owens')
+  ClusterStatusJob.clusters.each do |cluster|
+    ClusterStatusJob.perform_now(cluster.id)
+  end
 end


### PR DESCRIPTION
Enable turbostreams. This enables turbostreams and action cable so that we can update panels.  This steams the 3 cluster_status panels right now.