### PR TITLE
Show cluster status on first render and fix bug preventing refreshing twice

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -2,7 +2,8 @@ class JobsController < ApplicationController
   def index
     @jobs = Job.all
     @pct_jobs = Job.usage_w_percentage(Job.all_by_usage)
-    @active_jobs = ActiveJobs.all
-    @cluster_ids = ActiveJobs.clusters.map { |c| c.id }
+    #@active_jobs = ActiveJobs.all
+    #@cluster_ids = ActiveJobs.clusters.map { |c| c.id }
+    @clusters_with_info = ActiveJobs.clusters_with_info
   end
 end

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -2,8 +2,6 @@ class JobsController < ApplicationController
   def index
     @jobs = Job.all
     @pct_jobs = Job.usage_w_percentage(Job.all_by_usage)
-    #@active_jobs = ActiveJobs.all
-    #@cluster_ids = ActiveJobs.clusters.map { |c| c.id }
     @clusters_with_info = ActiveJobs.clusters_with_info
   end
 end

--- a/app/jobs/cluster_status_job.rb
+++ b/app/jobs/cluster_status_job.rb
@@ -2,43 +2,15 @@ class ClusterStatusJob < ApplicationJob
   queue_as :default
 
   class << self
-    def info_from_jobs(jobs)
-      gpu_jobs_running = jobs.count { |job| job.status == 'running' && job.native[:gres].include?("gpu") }
-      gpu_jobs_queued = jobs.count { |job| job.status == 'queued' && job.native[:gres].include?("gpu") }
-      jobs_running = jobs.count { |job| job.status == 'running' }
-      jobs_queued = jobs.count { |job| job.status == 'queued' }
-      {
-        'gpu_jobs_running':     gpu_jobs_running,
-        'gpu_jobs_queued':      gpu_jobs_queued,
-        'gpu_jobs_running_pct': (gpu_jobs_running + gpu_jobs_queued != 0) ? (gpu_jobs_running.to_f / (gpu_jobs_running + gpu_jobs_queued) * 100).to_i : 0,
-        'gpu_jobs_queued_pct':  (gpu_jobs_running + gpu_jobs_queued != 0) ? (gpu_jobs_queued.to_f / (gpu_jobs_running + gpu_jobs_queued) * 100).to_i : 0,
-        'jobs_running':         jobs_running,
-        'jobs_queued':          jobs_queued,
-        'jobs_running_pct':     (jobs_running + jobs_queued != 0) ? (jobs_running.to_f / (jobs_running + jobs_queued) * 100).to_i : 0,
-        'jobs_queued_pct':      (jobs_running + jobs_queued != 0) ? (jobs_queued.to_f / (jobs_running + jobs_queued) * 100).to_i : 0
-      }
-    end
-
-    def clusters
-      Rails.cache.fetch('clusters', expires_in: 12.hours) do
-        OodCore::Clusters.new(
-          OodCore::Clusters.load_file('/etc/ood/config/clusters.d/').reject do |c|
-            !c.errors.empty? || !c.allow? || c.kubernetes? || c.linux_host?
-          end
-        )
-      end
-    end
   end
 
   def perform(cluster_id)
-    cluster = self.class.clusters[cluster_id.to_sym]
-    info = self.class.info_from_jobs(cluster.job_adapter.info_all)
-    # broadcast info
-    opts = {
-              partial: 'jobs/system_status',
-              target: "cluster_status_#{cluster_id}",
-              locals: { cluster_info: info, cluster_name: cluster_id }
-            }
+    cluster = ActiveJobs.clusters[cluster_id.to_sym]
+    info = ActiveJobs.info_from_jobs(cluster.job_adapter.info_all)
+    puts 'Updating'
+    opts = {  partial: 'jobs/system_status',
+              target:  "cluster_status_#{cluster_id}",
+              locals:  { cluster_info: info, cluster_name: cluster_id } }
     Turbo::StreamsChannel.broadcast_replace_to("cluster_status_#{cluster_id}", **opts)
     self.class.set(wait: 15.minutes).perform_later(cluster_id)
   end

--- a/app/jobs/cluster_status_job.rb
+++ b/app/jobs/cluster_status_job.rb
@@ -40,6 +40,6 @@ class ClusterStatusJob < ApplicationJob
               locals: { cluster_info: info, cluster_name: cluster_id }
             }
     Turbo::StreamsChannel.broadcast_replace_to("cluster_status_#{cluster_id}", **opts)
-    self.class.set(wait: 30.seconds).perform_later(cluster_id)
+    self.class.set(wait: 15.minutes).perform_later(cluster_id)
   end
 end

--- a/app/models/active_jobs.rb
+++ b/app/models/active_jobs.rb
@@ -2,6 +2,23 @@
 
 class ActiveJobs
   class << self
+    def info_from_jobs(jobs)
+      gpu_jobs_running = jobs.count { |job| job.status == 'running' && job.native[:gres].include?("gpu") }
+      gpu_jobs_queued = jobs.count { |job| job.status == 'queued' && job.native[:gres].include?("gpu") }
+      jobs_running = jobs.count { |job| job.status == 'running' }
+      jobs_queued = jobs.count { |job| job.status == 'queued' }
+      {
+        'gpu_jobs_running':     gpu_jobs_running,
+        'gpu_jobs_queued':      gpu_jobs_queued,
+        'gpu_jobs_running_pct': (gpu_jobs_running + gpu_jobs_queued != 0) ? (gpu_jobs_running.to_f / (gpu_jobs_running + gpu_jobs_queued) * 100).to_i : 0,
+        'gpu_jobs_queued_pct':  (gpu_jobs_running + gpu_jobs_queued != 0) ? (gpu_jobs_queued.to_f / (gpu_jobs_running + gpu_jobs_queued) * 100).to_i : 0,
+        'jobs_running':         jobs_running,
+        'jobs_queued':          jobs_queued,
+        'jobs_running_pct':     (jobs_running + jobs_queued != 0) ? (jobs_running.to_f / (jobs_running + jobs_queued) * 100).to_i : 0,
+        'jobs_queued_pct':      (jobs_running + jobs_queued != 0) ? (jobs_queued.to_f / (jobs_running + jobs_queued) * 100).to_i : 0
+      }
+    end
+
     def clusters
       Rails.cache.fetch('clusters', expires_in: 12.hours) do
         OodCore::Clusters.new(
@@ -20,6 +37,15 @@ class ActiveJobs
             'jobs'    => c.job_adapter.info_all
           }
         end
+      end
+    end
+
+    def clusters_with_info
+      all.map do |c|
+        {
+          'cluster_name' => c['cluster'],
+          'info'         => info_from_jobs(c['jobs'])
+        }
       end
     end
   end

--- a/app/views/jobs/_system_status.html.erb
+++ b/app/views/jobs/_system_status.html.erb
@@ -1,50 +1,52 @@
-<div class='container border py-1 rounded-1'>
-    <h2><%= cluster_name.capitalize() %> Cluster</h2>
-    <div class="row justify-content-center">
-        <div class="col">
-            <div class="barchart">
-                <div class="bc-bar bar-<%= cluster_info[:gpu_jobs_running_pct] %> bg-primary">
-                    <p class="bar-value">
-                        <%= cluster_info[:gpu_jobs_running] %>
-                    </p>
-                    <p class="bar-label">
-                        Active GPU jobs
-                    </p>
+<div id="cluster_status_<%= cluster_name %>">
+    <div class='container border py-1 rounded-1'>
+        <h2><%= cluster_name.capitalize() %> Cluster</h2>
+        <div class="row justify-content-center">
+            <div class="col">
+                <div class="barchart">
+                    <div class="bc-bar bar-<%= cluster_info[:gpu_jobs_running_pct] %> bg-primary">
+                        <p class="bar-value">
+                            <%= cluster_info[:gpu_jobs_running] %>
+                        </p>
+                        <p class="bar-label">
+                            Active GPU jobs
+                        </p>
+                    </div>
+                    <div class="bc-bar bar-<%= cluster_info[:gpu_jobs_queued_pct] %> bg-primary">
+                        <p class="bar-value">
+                            <%= cluster_info[:gpu_jobs_queued] %>
+                        </p>
+                        <p class="bar-label">
+                            Queued GPU jobs
+                        </p>
+                    </div>
                 </div>
-                <div class="bc-bar bar-<%= cluster_info[:gpu_jobs_queued_pct] %> bg-primary">
-                    <p class="bar-value">
-                        <%= cluster_info[:gpu_jobs_queued] %>
-                    </p>
-                    <p class="bar-label">
-                        Queued GPU jobs
-                    </p>
-                </div>
-            </div>
-            <div class="bar-chart-title text-center">
-                <p>GPU Usage</p>
-            </div>
-        </div>
-        <div class="col">
-            <div class="barchart">
-                <div class="bc-bar bar-<%= cluster_info[:jobs_running_pct] %> bg-danger">
-                    <p class='bar-value'>
-                        <%= cluster_info[:jobs_running] %>
-                    </p>
-                    <p class="bar-label">
-                        Jobs Running
-                    </p>
-                </div>
-                <div class="bc-bar bar-<%= cluster_info[:jobs_queued_pct] %> bg-danger">
-                    <p class="bar-value">
-                        <%= cluster_info[:jobs_queued] %>
-                    </p>
-                    <p class="bar-label">
-                        Jobs Queued
-                    </p>
+                <div class="bar-chart-title text-center">
+                    <p>GPU Usage</p>
                 </div>
             </div>
-            <div class="bar-chart-title text-center">
-                <p>Jobs</p>
+            <div class="col">
+                <div class="barchart">
+                    <div class="bc-bar bar-<%= cluster_info[:jobs_running_pct] %> bg-danger">
+                        <p class='bar-value'>
+                            <%= cluster_info[:jobs_running] %>
+                        </p>
+                        <p class="bar-label">
+                            Jobs Running
+                        </p>
+                    </div>
+                    <div class="bc-bar bar-<%= cluster_info[:jobs_queued_pct] %> bg-danger">
+                        <p class="bar-value">
+                            <%= cluster_info[:jobs_queued] %>
+                        </p>
+                        <p class="bar-label">
+                            Jobs Queued
+                        </p>
+                    </div>
+                </div>
+                <div class="bar-chart-title text-center">
+                    <p>Jobs</p>
+                </div>
             </div>
         </div>
     </div>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -1,10 +1,10 @@
 
 <div class='row my-2'>
-  <%- @cluster_ids.each do |cluster| -%>
+  <%- @clusters_with_info.each do |cluster| -%>
   <div class='col-md-6 col-xs-12 p-2'>
-    <%= turbo_stream_from "cluster_status_#{cluster}" %>
-    <div id="cluster_status_<%= cluster %>">
-      page loading ...
+    <%= turbo_stream_from "cluster_status_#{cluster['cluster_name']}" %>
+    <div id="cluster_status_<%= cluster['cluster_name'] %>">
+      <%= render partial: 'system_status', locals: {cluster_name: cluster['cluster_name'], cluster_info: cluster['info']} %>
     </div>
   </div>
   <%- end -%>

--- a/app/views/jobs/index.html.erb
+++ b/app/views/jobs/index.html.erb
@@ -3,9 +3,7 @@
   <%- @clusters_with_info.each do |cluster| -%>
   <div class='col-md-6 col-xs-12 p-2'>
     <%= turbo_stream_from "cluster_status_#{cluster['cluster_name']}" %>
-    <div id="cluster_status_<%= cluster['cluster_name'] %>">
-      <%= render partial: 'system_status', locals: {cluster_name: cluster['cluster_name'], cluster_info: cluster['info']} %>
-    </div>
+    <%= render partial: 'system_status', locals: {cluster_name: cluster['cluster_name'], cluster_info: cluster['info']} %>
   </div>
   <%- end -%>
 </div>

--- a/config/initializers/startup_jobs.rb
+++ b/config/initializers/startup_jobs.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.after_initialize do
-  ClusterStatusJob.clusters.each do |cluster|
+  ActiveJobs.clusters.each do |cluster|
     ClusterStatusJob.perform_now(cluster.id)
   end
 end


### PR DESCRIPTION
A few parts to this pr:


* Display graphs on initial load
* Use model to populate updated data pushed to stream with job
* Move div with target id to partial, allowing stream to be refreshed more than once



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201735133575781/1202301293514034) by [Unito](https://www.unito.io)
